### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,6 @@
     "name": "Vortex",
     "version": "1.0.2",
     "author": "Abhiman G S",
-    "minAppVersion": "1.6.7",
+    "minAppVersion": "1.13.0",
     "authorUrl": "https://github.com/abhimangs"
 }

--- a/theme.css
+++ b/theme.css
@@ -107,12 +107,12 @@ body {
     --callout-radius: 4px;
     --callout-border-width: 0px;
     --callout-background-opacity: 0.2;
-    --callout-color-green: 50, 200, 100;
-    --callout-color-yellow: 255, 204, 0;
-    --callout-color-red: 255, 80, 80;
-    --callout-color-blue: 50, 150, 255;
-    --callout-color-purple: 150, 100, 250;
-    --callout-color-orange: 255, 150, 50;
+    --callout-color-green: rgb(50, 200, 100);
+    --callout-color-yellow: rgb(255, 204, 0);
+    --callout-color-red: rgb(255, 80, 80);
+    --callout-color-blue: rgb(50, 150, 255);
+    --callout-color-purple: rgb(150, 100, 250);
+    --callout-color-orange: rgb(255, 150, 50);
 }
 
 /* HEADING - GRADIENT UNDERLINE STYLES */
@@ -1111,11 +1111,11 @@ pre[class$='python']:before {
 .callout {
   overflow: hidden;
   border-style: solid;
-  border-color: rgba(var(--callout-color), var(--callout-border-opacity));
+  border-color: color-mix(in srgb, var(--callout-color) calc(var(--callout-border-opacity) * 100%), transparent);
   border-width: var(--callout-border-width);
   border-radius: var(--callout-radius);
   margin: 1em 0;
-  background-color: rgba(var(--callout-color), var(--callout-background-opacity));
+  background-color: color-mix(in srgb, var(--callout-color) calc(var(--callout-background-opacity) * 100%), transparent);
   padding: var(--callout-padding);
 }
 


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
